### PR TITLE
feat(container)!: upgrade app-template Helm chart to v5 (4.6.2 → 5.0.0)

### DIFF
--- a/kubernetes/apps/ai/ollama/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/ollama/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/open-webui/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/open-webui/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/echo-basicauth/app/ocirepository.yaml
+++ b/kubernetes/apps/default/echo-basicauth/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/echo-oidcauth/app/ocirepository.yaml
+++ b/kubernetes/apps/default/echo-oidcauth/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/default/echo/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/forgejo-runner/app/ocirepository.yaml
+++ b/kubernetes/apps/default/forgejo-runner/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/freshrss/app/ocirepository.yaml
+++ b/kubernetes/apps/default/freshrss/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/home-assistant/app/ocirepository.yaml
+++ b/kubernetes/apps/default/home-assistant/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/immich/app/ocirepository.yaml
+++ b/kubernetes/apps/default/immich/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/mosquitto/app/ocirepository.yaml
+++ b/kubernetes/apps/default/mosquitto/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/paperless/app/ocirepository.yaml
+++ b/kubernetes/apps/default/paperless/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/pihole/app/ocirepository.yaml
+++ b/kubernetes/apps/default/pihole/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/smtp-relay/app/ocirepository.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/wg-easy/app/ocirepository.yaml
+++ b/kubernetes/apps/default/wg-easy/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/whoami/app/ocirepository.yaml
+++ b/kubernetes/apps/default/whoami/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/zigbee/app/ocirepository.yaml
+++ b/kubernetes/apps/default/zigbee/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/zwave/app/ocirepository.yaml
+++ b/kubernetes/apps/default/zwave/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/development/atuin/app/ocirepository.yaml
+++ b/kubernetes/apps/development/atuin/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/unifi/app/ocirepository.yaml
+++ b/kubernetes/apps/network/unifi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/gatus/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/gatus/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/volsync-system/kopia/app/ocirepository.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
## Changes

Upgrade app-template from v4.6.2 to v5.0.0 across all 25 referencing workloads.

## Breaking changes (low impact)

- **automountServiceAccountToken** defaults to `false` — no workloads in this repo use SA token mounting, so no action needed.
- **createDefaultServiceAccount** defaults to `true` — each workload now gets its own dedicated SA (security improvement over falling back to the namespace default).
- **serviceMonitor.jobLabel** defaults to `app.kubernetes.io/name` — could affect Prometheus queries/alerting rules that reference specific job names. No jobLabel overrides were needed in the rendered output.

## No-impact changes

The following breaking changes do not affect this codebase:
- `rawResources` — not used
- `networkPolicies` targeting — not used

## Verification

- `flux-local build all --enable-helm` passes cleanly
- All 110 rendered resources confirm `helm.sh/chart: app-template-5.0.0`
- No v4 artifacts remain in the build output
