### PR TITLE
feat: add thin-client namespace for Wyse 5070 remote desktop

### DIFF
--- a/kubernetes/apps/thin-client/README.md
+++ b/kubernetes/apps/thin-client/README.md
@@ -1,0 +1,99 @@
+# thin-client/
+
+Remote Linux desktop infrastructure for Dell Wyse 5070 thin clients.
+
+## Architecture
+
+The Wyse 5070 thin client PXE-boots a minimal Alpine Linux environment that runs entirely in RAM, then auto-connects to a Linux desktop (XFCE4) running as a container on the Kubernetes cluster.
+
+```
+┌──────────────────────┐     ┌──────────────────────────────────┐
+│   Wyse 5070          │     │   Kubernetes Cluster             │
+│                      │     │                                  │
+│  ┌────────────────┐  │     │  ┌────────────┐                  │
+│  │ UEFI PXE Boot  │──│──DHCP──│  netboot   │ (iPXE + TFTP)   │
+│  └───────┬────────┘  │     │  └────────────┘                  │
+│          │           │     │                                  │
+│  ┌───────▼────────┐  │     │  ┌────────────────────────────┐  │
+│  │ Alpine Linux   │  │     │  │  desktop                   │  │
+│  │ (runs in RAM)  │  │     │  │  XFCE4 + KasmVNC           │  │
+│  │                │──│─HTTPS──│  linuxserver/webtop         │  │
+│  │ Chromium Kiosk │  │     │  │                            │  │
+│  └────────────────┘  │     │  │  Persistent: 20Gi Ceph PVC │  │
+│                      │     │  └────────────────────────────┘  │
+└──────────────────────┘     └──────────────────────────────────┘
+```
+
+## Apps
+
+| App | Purpose | Image |
+|-----|---------|-------|
+| [desktop](desktop/) | XFCE4 Linux desktop (KasmVNC web access) | `lscr.io/linuxserver/webtop:alpine-xfce` |
+| [netboot](netboot/) | iPXE boot server (TFTP + HTTP + web UI) | `ghcr.io/netbootxyz/netbootxyz` |
+
+## Boot Chain
+
+1. **Wyse 5070 powers on** → UEFI PXE boot request
+2. **DHCP server** responds with `next-server` (netboot LoadBalancer IP) and `filename` (ipxe.efi)
+3. **iPXE firmware** chainloads from the netboot pod via TFTP
+4. **iPXE script** (`custom.ipxe`) downloads Alpine Linux kernel + initramfs from Alpine CDN
+5. **Alpine Linux** boots diskless (entirely in RAM)
+6. **Post-boot script** installs Chromium, Openbox, and auto-starts X11
+7. **Chromium kiosk** connects to `https://desktop.<domain>` — full XFCE desktop via KasmVNC
+
+## DHCP Configuration
+
+Your network DHCP server must be configured to point PXE clients at the netboot service:
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| Option 66 (`next-server`) | `192.168.1.70` | netboot LoadBalancer IP |
+| Option 67 (`bootfile-name`) | `netboot.xyz.efi` | iPXE UEFI binary |
+
+### UniFi Controller
+
+In the UniFi Network UI:
+1. Go to **Settings → Networks → (your LAN)**
+2. Enable **DHCP Network Boot**
+3. Set **Server** to `192.168.1.70`
+4. Set **File** to `netboot.xyz.efi`
+
+> **Tip**: To scope this to only the Wyse 5070, create a DHCP reservation for the thin client's MAC address and apply the boot options only to that reservation.
+
+## Desktop Access
+
+| Method | URL | Use Case |
+|--------|-----|----------|
+| Internal (browser) | `https://desktop.<domain>` | Access from any device on the LAN |
+| Thin client (auto) | Chromium kiosk → same URL | Wyse 5070 auto-connects on boot |
+
+## First-Time Alpine Setup
+
+After the Wyse 5070 boots into Alpine for the first time, you need to run the setup script to install the desktop client packages:
+
+```sh
+# From the Alpine console (Alt+F2 for second TTY)
+wget -qO- http://192.168.1.70:3000/config/menus/custom/thin-client-setup.sh | sh
+```
+
+This installs Chromium, Openbox, Intel GPU drivers, and configures auto-login + kiosk mode. After setup, the thin client will automatically boot into the desktop on subsequent restarts.
+
+> **Note**: For a fully automated experience, consider building a custom Alpine overlay (`apkovl.tar.gz`) with these packages pre-installed and hosting it on the netboot server.
+
+## Persistent Storage
+
+The desktop pod uses a 20Gi Ceph block PVC mounted at `/config`. This persists:
+- Desktop configuration and customizations
+- Application data and settings  
+- User files stored under `/config`
+
+Backups are managed by VolSync (hourly Kopia snapshots to S3).
+
+## Future Enhancements
+
+- [ ] Custom Alpine overlay (`apkovl.tar.gz`) for zero-touch thin client boot
+- [ ] XRDP server container for native RDP multi-monitor support
+- [ ] Moonlight/Sunshine streaming for GPU-accelerated desktop (DGX Spark worker)
+- [ ] Network policies restricting desktop access to thin client subnet
+- [ ] Authentik SSO integration for web-based desktop access
+- [ ] Multiple desktop profiles (dev workstation, media center, etc.)

--- a/kubernetes/apps/thin-client/desktop/app/helmrelease.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: desktop
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: desktop
+  interval: 1h
+  values:
+    controllers:
+      desktop:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: lscr.io/linuxserver/webtop
+              tag: alpine-xfce
+            env:
+              PUID: "1000"
+              PGID: "1000"
+              TZ: America/New_York
+              # CUSTOM_PORT: "3000"
+              # CUSTOM_HTTPS_PORT: "3001"
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                memory: 4Gi
+            securityContext:
+              seccompProfile:
+                type: Unconfined
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+    service:
+      app:
+        ports:
+          http:
+            port: 3000
+          https:
+            port: 3001
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+        hostnames:
+          - "desktop.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 3000
+    persistence:
+      config:
+        existingClaim: desktop
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/thin-client/desktop/app/kustomization.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/thin-client/desktop/app/ocirepository.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: desktop
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/thin-client/desktop/ks.yaml
+++ b/kubernetes/apps/thin-client/desktop/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: desktop
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/thin-client/desktop/app
+  postBuild:
+    substitute:
+      APP: desktop
+      VOLSYNC_CAPACITY: 20Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: thin-client
+  wait: false

--- a/kubernetes/apps/thin-client/kustomization.yaml
+++ b/kubernetes/apps/thin-client/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thin-client
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./desktop/ks.yaml
+  - ./netboot/ks.yaml

--- a/kubernetes/apps/thin-client/namespace.yaml
+++ b/kubernetes/apps/thin-client/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: thin-client

--- a/kubernetes/apps/thin-client/netboot/app/configmap.yaml
+++ b/kubernetes/apps/thin-client/netboot/app/configmap.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: netboot-ipxe
+data:
+  custom.ipxe: |
+    #!ipxe
+    # Wyse 5070 Thin Client — Custom boot menu
+    # Boots Alpine Linux in diskless mode with auto-start desktop client
+
+    :start
+    menu Thin Client Boot Menu
+    item --gap --    ---- Thin Client Options ----
+    item alpine      Boot Alpine Linux (Thin Client Desktop)
+    item netbootxyz  netboot.xyz Main Menu
+    item shell       iPXE Shell
+    choose --default alpine --timeout 5000 target && goto ${target}
+
+    :alpine
+    set alpine-mirror http://dl-cdn.alpinelinux.org/alpine/latest-stable
+    set alpine-arch x86_64
+
+    echo Booting Alpine Linux thin client...
+    kernel ${alpine-mirror}/releases/${alpine-arch}/netboot/vmlinuz-lts alpine_repo=${alpine-mirror}/main modloop=${alpine-mirror}/releases/${alpine-arch}/netboot/modloop-lts modules=loop,squashfs,sd-mod,usb-storage quiet nomodeset
+    initrd ${alpine-mirror}/releases/${alpine-arch}/netboot/initramfs-lts
+    boot
+
+    :netbootxyz
+    chain --autofree https://boot.netboot.xyz/ipxe/netboot.xyz.efi
+
+    :shell
+    shell
+  thin-client-setup.sh: |
+    #!/bin/sh
+    # Post-boot setup script for Alpine thin client
+    # Run this after Alpine boots to configure the desktop client
+    #
+    # Usage: wget -qO- http://netboot.thin-client.svc.cluster.local:3000/config/menus/custom/thin-client-setup.sh | sh
+    #
+    set -e
+
+    echo "=== Thin Client Setup ==="
+
+    # Enable community repo
+    echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories
+
+    # Install packages
+    apk update
+    apk add \
+      xorg-server \
+      xf86-video-intel \
+      xf86-input-libinput \
+      mesa-dri-gallium \
+      eudev \
+      dbus \
+      xfce4-terminal \
+      chromium \
+      freerdp \
+      pulseaudio \
+      alsa-utils \
+      font-noto \
+      font-noto-emoji \
+      openbox \
+      xdotool
+
+    # Configure auto-login
+    setup-devd udev
+
+    # Create thin client user
+    adduser -D -s /bin/sh user
+    echo "user:user" | chpasswd
+
+    # Create Openbox autostart to launch browser in kiosk mode
+    mkdir -p /home/user/.config/openbox
+    cat > /home/user/.config/openbox/autostart << 'AUTOSTART'
+    # Wait for network
+    sleep 3
+
+    # Launch Chromium in kiosk mode pointed at the desktop
+    chromium-browser \
+      --no-first-run \
+      --disable-translate \
+      --disable-infobars \
+      --disable-suggestions-service \
+      --disable-save-password-bubble \
+      --disable-session-crashed-bubble \
+      --kiosk \
+      --noerrdialogs \
+      --no-default-browser-check \
+      --autoplay-policy=no-user-gesture-required \
+      --start-fullscreen \
+      "https://desktop.${SECRET_DOMAIN}" &
+    AUTOSTART
+    chown -R user:user /home/user
+
+    # Create xinitrc
+    cat > /home/user/.xinitrc << 'XINIT'
+    exec openbox-session
+    XINIT
+    chown user:user /home/user/.xinitrc
+
+    # Auto-start X on tty1
+    cat > /etc/profile.d/auto-startx.sh << 'STARTX'
+    if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+      exec startx
+    fi
+    STARTX
+
+    # Auto-login user on tty1
+    sed -i 's|^tty1.*|tty1::respawn:/bin/login -f user|' /etc/inittab
+
+    echo "=== Setup complete. Rebooting into desktop... ==="
+    kill -HUP 1  # Re-read inittab

--- a/kubernetes/apps/thin-client/netboot/app/configmap.yaml
+++ b/kubernetes/apps/thin-client/netboot/app/configmap.yaml
@@ -15,15 +15,15 @@ data:
     item alpine      Boot Alpine Linux (Thin Client Desktop)
     item netbootxyz  netboot.xyz Main Menu
     item shell       iPXE Shell
-    choose --default alpine --timeout 5000 target && goto ${target}
+    choose --default alpine --timeout 5000 target && goto $${target}
 
     :alpine
     set alpine-mirror http://dl-cdn.alpinelinux.org/alpine/latest-stable
     set alpine-arch x86_64
 
     echo Booting Alpine Linux thin client...
-    kernel ${alpine-mirror}/releases/${alpine-arch}/netboot/vmlinuz-lts alpine_repo=${alpine-mirror}/main modloop=${alpine-mirror}/releases/${alpine-arch}/netboot/modloop-lts modules=loop,squashfs,sd-mod,usb-storage quiet nomodeset
-    initrd ${alpine-mirror}/releases/${alpine-arch}/netboot/initramfs-lts
+    kernel $${alpine-mirror}/releases/$${alpine-arch}/netboot/vmlinuz-lts alpine_repo=$${alpine-mirror}/main modloop=$${alpine-mirror}/releases/$${alpine-arch}/netboot/modloop-lts modules=loop,squashfs,sd-mod,usb-storage quiet nomodeset
+    initrd $${alpine-mirror}/releases/$${alpine-arch}/netboot/initramfs-lts
     boot
 
     :netbootxyz
@@ -102,7 +102,7 @@ data:
 
     # Auto-start X on tty1
     cat > /etc/profile.d/auto-startx.sh << 'STARTX'
-    if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+    if [ -z "$$DISPLAY" ] && [ "$$(tty)" = "/dev/tty1" ]; then
       exec startx
     fi
     STARTX

--- a/kubernetes/apps/thin-client/netboot/app/helmrelease.yaml
+++ b/kubernetes/apps/thin-client/netboot/app/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netboot
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: netboot
+  interval: 1h
+  values:
+    controllers:
+      netboot:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          http:
+            image:
+              repository: ghcr.io/netbootxyz/netbootxyz
+              tag: 0.7.6-nbxyz3
+            env:
+              TZ: America/New_York
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+    service:
+      app:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "192.168.1.70"
+        ports:
+          http:
+            port: 3000
+          tftp:
+            port: 69
+            protocol: UDP
+    route:
+      app:
+        hostnames:
+          - "netboot.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 3000
+    persistence:
+      config:
+        type: configMap
+        name: netboot-ipxe
+        globalMounts:
+          - path: /config/menus/custom
+            readOnly: true

--- a/kubernetes/apps/thin-client/netboot/app/kustomization.yaml
+++ b/kubernetes/apps/thin-client/netboot/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/thin-client/netboot/app/ocirepository.yaml
+++ b/kubernetes/apps/thin-client/netboot/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: netboot
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/thin-client/netboot/ks.yaml
+++ b/kubernetes/apps/thin-client/netboot/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: netboot
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/thin-client/netboot/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: thin-client
+  wait: false


### PR DESCRIPTION
## Summary

Deploy a remote Linux desktop (XFCE4) on Kubernetes for a Dell Wyse 5070 thin client, with iPXE network booting.

## Components

### `thin-client/desktop`
- **Image**: `linuxserver/webtop:alpine-xfce` (XFCE4 + KasmVNC)
- **Access**: `https://desktop.<domain>` via envoy-internal HTTPRoute
- **Storage**: 20Gi Ceph PVC with VolSync hourly backups
- **Resources**: 500m CPU / 2-4Gi RAM

### `thin-client/netboot`
- **Image**: `netbootxyz/netbootxyz` (iPXE + TFTP + HTTP)
- **Access**: LoadBalancer on `192.168.1.70` (TFTP 69/UDP + HTTP 3000), plus `https://netboot.<domain>` web UI
- **Boot menu**: Custom iPXE script auto-boots Alpine Linux with 5s timeout
- **Setup script**: Served via ConfigMap — installs Chromium, Openbox, Intel GPU drivers, configures kiosk auto-login

## Boot Chain

```
Wyse 5070 UEFI PXE → DHCP next-server (192.168.1.70) → iPXE chainload
→ Custom boot menu → Alpine Linux kernel+initramfs from CDN (diskless, in RAM)
→ Post-boot setup script → Chromium kiosk → desktop.<domain>
```

## Pre-merge Checklist

- [ ] Verify `192.168.1.70` is available in Cilium LB IP pool
- [ ] Review netboot.xyz image tag (may need pinning)
- [ ] Review webtop image tag (Renovate will auto-pin)

## Post-merge Setup

1. Configure DHCP Option 66/67 on UniFi (see `README.md`)
2. First boot: run setup script from Alpine console (one-time)
3. Subsequent boots are fully automatic