### PR TITLE
fix: add BackendTLSPolicy and cert-manager CSI TLS for desktop

### DIFF
--- a/kubernetes/apps/thin-client/desktop/app/backendtlspolicy.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/backendtlspolicy.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://schemas.tholinka.dev/gateway.networking.k8s.io/backendtlspolicy_v1alpha3.json
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: desktop-backend-tls
+spec:
+  targetRefs:
+    - group: ''
+      kind: Service
+      name: desktop
+      sectionName: https
+  validation:
+    caCertificateRefs:
+      - name: rnatr-internal-ca
+        group: ''
+        kind: Secret
+    hostname: desktop.thin-client.svc.cluster.local

--- a/kubernetes/apps/thin-client/desktop/app/helmrelease.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
       app:
         ports:
           https:
+            appProtocol: https
             port: 6901
     route:
       app:
@@ -74,3 +75,22 @@ spec:
         sizeLimit: 512Mi
         globalMounts:
           - path: /dev/shm
+      tls:
+        type: custom
+        volumeSpec:
+          csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-name: rnatr-internal-ca
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/dns-names: desktop.thin-client.svc.cluster.local
+        advancedMounts:
+          desktop:
+            app:
+              - path: /etc/ssl/certs/ssl-cert-snakeoil.pem
+                subPath: tls.crt
+                readOnly: true
+              - path: /etc/ssl/private/ssl-cert-snakeoil.key
+                subPath: tls.key
+                readOnly: true

--- a/kubernetes/apps/thin-client/desktop/app/kustomization.yaml
+++ b/kubernetes/apps/thin-client/desktop/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./backendtlspolicy.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/thin-client/desktop/ks.yaml
+++ b/kubernetes/apps/thin-client/desktop/ks.yaml
@@ -8,6 +8,8 @@ spec:
   components:
     - ../../../../components/volsync
   dependsOn:
+    - name: cert-manager-csi-driver
+      namespace: cert-manager
     - name: rook-ceph-cluster
       namespace: rook-ceph
   interval: 1h


### PR DESCRIPTION
## Problem

Envoy Gateway sends plain HTTP to the desktop backend, but Kasm serves HTTPS-only on port 6901. This causes:
```
upstream connect error or disconnect/reset before headers
```
And Kasm logs show:
```
non-SSL connection disallowed
```

## Fix

### 1. cert-manager CSI driver volume
The CSI driver issues a TLS cert inline from `rnatr-internal-ca` (no Certificate CRD needed) and mounts it at the KasmVNC snakeoil cert paths:
- `tls.crt` → `/etc/ssl/certs/ssl-cert-snakeoil.pem`
- `tls.key` → `/etc/ssl/private/ssl-cert-snakeoil.key`

DNS SAN: `desktop.thin-client.svc.cluster.local`

### 2. BackendTLSPolicy
Tells Envoy to connect to the `desktop` service over TLS, validating against the `rnatr-internal-ca` secret (distributed by trust-manager Bundle).

### 3. Service appProtocol
Added `appProtocol: https` on the service port for protocol discovery.

### 4. Flux dependency
Desktop now depends on `cert-manager-csi-driver` so the CSI driver is ready before the pod starts.

## Files changed
- `desktop/app/backendtlspolicy.yaml` — **new**
- `desktop/app/helmrelease.yaml` — CSI volume mount + appProtocol
- `desktop/app/kustomization.yaml` — added backendtlspolicy reference
- `desktop/ks.yaml` — added cert-manager-csi-driver dependency